### PR TITLE
Local mealierc support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ ${PRODUCT}.mac: *.go
 ifeq (${USE_DOCKER}, 1)
 	docker run --rm -v ${PWD}:${GO_SRC}/${FULL_PRODUCT} -w ${GO_SRC}/${FULL_PRODUCT} ${GOLANG_DOCKER_IMAGE} make mac
 else
-	GOOS=darwin GOARCH=386 go build -o ${PRODUCT}.mac
+	GOOS=darwin GOARCH=amd64 go build -o ${PRODUCT}.mac
 endif
 
 ${PRODUCT}.exe: *.go

--- a/configDefaults.go
+++ b/configDefaults.go
@@ -29,10 +29,14 @@ func initConfigDefaults() {
 }
 
 func initMealierc() {
-	mealiercFilename := filepath.Join(os.Getenv(homeVar), mealierc)
+	mealiercFilename := mealierc
 	_, err := os.Stat(mealiercFilename)
 	if os.IsNotExist(err) {
-		return
+		mealiercFilename = filepath.Join(os.Getenv(homeVar), mealierc)
+		_, err := os.Stat(mealiercFilename)
+		if os.IsNotExist(err) {
+			return
+		}
 	}
 
 	file, err := os.Open(mealiercFilename)

--- a/index.go
+++ b/index.go
@@ -9,7 +9,7 @@ import (
 
 var appName = "mealie-crypt"
 var appDescription = "Utility for teams to manage sensitive information"
-var version = "1.2.3"
+var version = "1.2.4"
 var copyrightYear = 2018
 var copyrightHolder = "Warren Hodgkinson"
 


### PR DESCRIPTION
- Add local mealierc override.
- Fix build error "unsupported GOOS/GOARCH pair darwin/386" relating to 64bit only support for MacOS